### PR TITLE
Update DNS server

### DIFF
--- a/quantumutlx/fakeiapx.conf
+++ b/quantumutlx/fakeiapx.conf
@@ -1,3 +1,7 @@
+#Update 21.02.2020
+#Optimize dns server & add NextDNS server
+#Force all links to go through the TCP except DNS port 53
+
 #Update 09.02.2020
 #add exceptions rule (by BigDargon - hostsVN)
 
@@ -31,11 +35,11 @@
 
 
 [general]
+udp_whitelist=53
 ;server_check_url=http://www.google.com/generate_204
 ;geo_location_checker=http://www.example.com/json/, https://www.example.com/script.js
 ;dns_exclusion_list=*.qq.com, qq.com, *.cmpassport.com
 ;ssid_suspended_list=LINK_22E174, LINK_22E175
-;udp_whitelist=53, 123, 1900, 80-443
 ;excluded_routes= 192.168.0.0/16, 172.16.0.0/12, 100.64.0.0/10, 10.0.0.0/8
 ;icmp_auto_reply=true
 
@@ -46,9 +50,8 @@
 #
 [dns]
 server=1.1.1.1
-server=1.0.0.1
 server=8.8.8.8
-server=8.8.4.4
+server=45.90.28.0
 
 
 #


### PR DESCRIPTION
* Tối ưu các máy chủ DNS và thêm DNS mới `NextDNS`
* Buộc tất cả link phải qua cổng TCP để phân giải HTTPS (tên miền *.googlevideo.com đôi khi không phân giải HTTPS), trừ cổng 53 để phân giải DNS